### PR TITLE
Add comparison of factorial in Go and Zig

### DIFF
--- a/factorial/.gitignore
+++ b/factorial/.gitignore
@@ -1,0 +1,8 @@
+fact-go
+fact-zig
+fact-gmp-zig
+fact-linear-go
+fact-linear-zig
+fact-linear-gmp-zig
+zig-cache
+*.o

--- a/factorial/fact-gmp.zig
+++ b/factorial/fact-gmp.zig
@@ -1,0 +1,112 @@
+const c = @cImport({
+    @cInclude("gmp.h");
+});
+const std = @import("std");
+const Channel = std.event.Channel;
+
+pub const io_mode = .evented;
+
+pub fn main() !void {
+    try fact(3000000);
+}
+
+fn fact(n: u64) !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+    const allocator = &arena.allocator;
+
+    const cores = previousPowerOfTwo(try std.Thread.cpuCount());
+
+    if (n < cores) {
+        var x: c.mpz_t = undefined;
+        c.mpz_init(&x);
+        bigIntMulRange(&x, 1, n);
+        c.mpz_clear(&x);
+        return;
+    }
+
+    var buffer = try allocator.alloc(*c.mpz_t, cores);
+    var out = try allocator.create(Channel(*c.mpz_t));
+    out.init(buffer);
+
+    var i: usize = 0;
+    while (i < cores) : (i += 1) {
+        const start = @divFloor(i * n, cores) + 1;
+        const stop = @divFloor((i + 1) * n, cores);
+        const buf = try allocator.alloc(u64, 2);
+        const in = try allocator.create(Channel(u64));
+        in.init(buf);
+        (try allocator.create(@Frame(parallelMulRange))).* = async parallelMulRange(in, out);
+        in.put(start);
+        in.put(stop);
+    }
+
+    var in = out;
+    var procs = cores;
+
+    while (procs > 1) {
+        buffer = try allocator.alloc(*c.mpz_t, procs);
+        out = try allocator.create(Channel(*c.mpz_t));
+        out.init(buffer);
+        var odd = procs % 2 == 1;
+        procs = @divFloor(procs, 2);
+        i = 0;
+        while (i < procs) : (i += 1) {
+            (try allocator.create(@Frame(reduceMul))).* = async reduceMul(in, out);
+        }
+        if (odd) {
+            out.put(in.get());
+            procs += 1;
+        }
+        in = out;
+    }
+    c.mpz_clear(in.get());
+}
+
+fn previousPowerOfTwo(x: usize) usize {
+    comptime var bits = usize.bit_count;
+    comptime var i = 1;
+    var y = x;
+    inline while (i < bits) : (i *= 2) {
+        y = y | (y >> i);
+    }
+    return y - (y >> 1);
+}
+
+fn reduceMul(in: *Channel(*c.mpz_t), out: *Channel(*c.mpz_t)) void {
+    const a = in.get();
+    const b = in.get();
+
+    c.mpz_mul(a, a, b);
+    out.put(a);
+    c.mpz_clear(b);
+}
+
+fn parallelMulRange(in: *Channel(u64), out: *Channel(*c.mpz_t)) void {
+    var start = in.get();
+    var stop = in.get();
+    var x: c.mpz_t = undefined;
+    c.mpz_init(&x);
+    bigIntMulRange(&x, start, stop);
+    out.put(&x);
+}
+
+fn bigIntMulRange(out: *c.mpz_t, a: u64, b: u64) void {
+    if (a == b) {
+        c.mpz_init_set_ui(out, a);
+        return;
+    }
+
+    var l: c.mpz_t = undefined;
+    c.mpz_init(&l);
+    var r: c.mpz_t = undefined;
+    c.mpz_init(&r);
+
+    const m = @divFloor((a + b), 2);
+    bigIntMulRange(&l, a, m);
+    bigIntMulRange(&r, m + 1, b);
+
+    c.mpz_mul(out, &l, &r);
+
+    c.mpz_clear(&l);
+    c.mpz_clear(&r);
+}

--- a/factorial/fact-linear-gmp.zig
+++ b/factorial/fact-linear-gmp.zig
@@ -1,0 +1,35 @@
+const c = @cImport({
+    @cInclude("gmp.h");
+});
+
+pub fn main() void {
+    fact(3000000);
+}
+
+fn fact(n: u64) void {
+    var x: c.mpz_t = undefined;
+    c.mpz_init(&x);
+    bigIntMultRange(&x, 1, n);
+    c.mpz_clear(&x);
+}
+
+fn bigIntMultRange(out: *c.mpz_t, a: u64, b: u64) void {
+    if (a == b) {
+        c.mpz_init_set_ui(out, a);
+        return;
+    }
+
+    var l: c.mpz_t = undefined;
+    c.mpz_init(&l);
+    var r: c.mpz_t = undefined;
+    c.mpz_init(&r);
+
+    const m = @divFloor((a + b), 2);
+    bigIntMultRange(&l, a, m);
+    bigIntMultRange(&r, m + 1, b);
+
+    c.mpz_mul(out, &l, &r);
+
+    c.mpz_clear(&l);
+    c.mpz_clear(&r);
+}

--- a/factorial/fact-linear.go
+++ b/factorial/fact-linear.go
@@ -1,0 +1,26 @@
+// Package factorial allows for users to calculate the factorial of any int64 in the form of a big.Int.
+// The calculations can be done sequentially or concurrently.
+package main
+
+import (
+	"math/big"
+)
+
+func main() {
+	Factorial(3000000)
+}
+
+// Factorial calculates the factorial of n.
+// The calculation is done sequentially.
+// If n < 0, -1 is returned.
+func Factorial(n int64) *big.Int {
+	if n == 0 {
+		return big.NewInt(1)
+	}
+	if n < 0 {
+		return big.NewInt(-1)
+	}
+	out := big.NewInt(1)
+	out.MulRange(1, n)
+	return out
+}

--- a/factorial/fact-linear.zig
+++ b/factorial/fact-linear.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const BigInt = std.math.big.Int;
+
+pub fn main() !void {
+    try fact(3000000);
+}
+
+fn fact(n: u64) !void {
+    const allocator = std.heap.direct_allocator;
+    var x = try BigInt.init(allocator);
+    defer x.deinit();
+    try bigIntMultRange(allocator, &x, 1, n);
+}
+
+fn bigIntMultRange(allocator: *Allocator, out: *BigInt, a: u64, b: u64) anyerror!void {
+    if (a == b) {
+        try out.set(a);
+        return;
+    }
+
+    var l = try BigInt.init(allocator);
+    var r = try BigInt.init(allocator);
+    defer l.deinit();
+    defer r.deinit();
+
+    const m = @divFloor((a + b), 2);
+    try bigIntMultRange(allocator, &l, a, m);
+    try bigIntMultRange(allocator, &r, m + 1, b);
+
+    try BigInt.mul(out, l, r);
+}

--- a/factorial/fact.go
+++ b/factorial/fact.go
@@ -1,0 +1,89 @@
+// Package factorial allows for users to calculate the factorial of any int64 in the form of a big.Int.
+// The calculations can be done sequentially or concurrently.
+package main
+
+import (
+	"math/big"
+	"runtime"
+)
+
+func main() {
+	ParallelFactorial(3000000)
+}
+
+// ParallelFactorial calculates the factorial of n.
+// The calculation is done concurrently.
+// A go routine is created for each proc.
+// If n < 0, -1 is returned.
+func ParallelFactorial(n int64) *big.Int {
+	if n == 0 {
+		return big.NewInt(1)
+	}
+	if n < 0 {
+		return big.NewInt(-1)
+	}
+	procs := previousPowerOfTwo(int64(runtime.GOMAXPROCS(0)))
+	if n < procs {
+		return Factorial(n)
+	}
+
+	outRange := make(chan *big.Int, procs)
+
+	for i := int64(0); i < procs; i++ {
+		go mulRange(i*n/procs+1, (i+1)*n/procs, outRange)
+	}
+
+	in := outRange
+	for procs > 1 {
+		out := make(chan *big.Int, procs/2+1)
+		odd := false
+		if procs%2 == 1 {
+			odd = true
+		}
+		procs /= 2
+		for i := int64(0); i < procs; i++ {
+			go reduceMul(in, out)
+		}
+		if odd {
+			out <- <-in
+			procs++
+		}
+		in = out
+	}
+	return <-in
+}
+
+func reduceMul(in <-chan *big.Int, out chan<- *big.Int) {
+	total := <-in
+	n := <-in
+	total.Mul(total, n)
+	out <- total
+}
+
+func previousPowerOfTwo(x int64) int64 {
+	for i := 1; i < 64; i *= 2 {
+		x = x | (x >> i)
+	}
+	return x - (x >> 1)
+}
+
+func mulRange(x int64, y int64, out chan<- *big.Int) {
+	total := big.NewInt(0)
+	total.MulRange(x, y)
+	out <- total
+}
+
+// Factorial calculates the factorial of n.
+// The calculation is done sequentially.
+// If n < 0, -1 is returned.
+func Factorial(n int64) *big.Int {
+	if n == 0 {
+		return big.NewInt(1)
+	}
+	if n < 0 {
+		return big.NewInt(-1)
+	}
+	out := big.NewInt(1)
+	out.MulRange(1, n)
+	return out
+}

--- a/factorial/fact.zig
+++ b/factorial/fact.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const BigInt = std.math.big.Int;
+const Channel = std.event.Channel;
+
+pub const io_mode = .evented;
+
+pub fn main() !void {
+    try fact(3000000);
+}
+
+fn fact(n: u64) !void {
+    const allocator = std.heap.c_allocator;
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    const arenaAllocator = &arena.allocator;
+
+    const cores = previousPowerOfTwo(try std.Thread.cpuCount());
+
+    if (n < cores) {
+        var x = try BigInt.init(allocator);
+        defer x.deinit();
+        try bigIntMultRange(allocator, &x, 1, n);
+        return;
+    }
+
+    var buffer = try arenaAllocator.alloc(*BigInt, cores);
+    var out = try arenaAllocator.create(Channel(*BigInt));
+    out.init(buffer);
+
+    var i: usize = 0;
+    while (i < cores) : (i += 1) {
+        const start = @divFloor(i * n, cores) + 1;
+        const stop = @divFloor((i + 1) * n, cores);
+        const buf = try arenaAllocator.alloc(u64, 2);
+        const in = try arenaAllocator.create(Channel(u64));
+        in.init(buf);
+        (try arenaAllocator.create(@Frame(parallelMulRange))).* = async parallelMulRange(allocator, in, out);
+        in.put(start);
+        in.put(stop);
+    }
+
+    var in = out;
+    var procs = cores;
+    while (procs > 1) {
+        buffer = try arenaAllocator.alloc(*BigInt, procs);
+        out = try arenaAllocator.create(Channel(*BigInt));
+        out.init(buffer);
+        var odd = procs % 2 == 1;
+        procs = @divFloor(procs, 2);
+        i = 0;
+        while (i < procs) : (i += 1) {
+            (try arenaAllocator.create(@Frame(reduceMul))).* = async reduceMul(in, out);
+        }
+        if (odd) {
+            out.put(in.get());
+            procs += 1;
+        }
+        in = out;
+    }
+    var x = in.get();
+}
+
+fn previousPowerOfTwo(x: usize) usize {
+    comptime var bits = usize.bit_count;
+    comptime var i = 1;
+    var y = x;
+    inline while (i < bits) : (i *= 2) {
+        y = y | (y >> i);
+    }
+    return y - (y >> 1);
+}
+
+fn reduceMul(in: *Channel(*BigInt), out: *Channel(*BigInt)) !void {
+    const a = in.get();
+    const b = in.get();
+    defer b.deinit();
+
+    try BigInt.mul(a, a.*, b.*);
+    out.put(a);
+}
+
+fn parallelMulRange(allocator: *Allocator, in: *Channel(u64), out: *Channel(*BigInt)) !void {
+    var start = in.get();
+    var stop = in.get();
+    var x = try BigInt.init(allocator);
+    try bigIntMultRange(allocator, &x, start, stop);
+    out.put(&x);
+}
+
+fn bigIntMultRange(allocator: *Allocator, out: *BigInt, a: u64, b: u64) anyerror!void {
+    if (a == b) {
+        try out.set(a);
+        return;
+    }
+
+    var l = try BigInt.init(allocator);
+    var r = try BigInt.init(allocator);
+    defer l.deinit();
+    defer r.deinit();
+
+    const m = @divFloor((a + b), 2);
+    try bigIntMultRange(allocator, &l, a, m);
+    try bigIntMultRange(allocator, &r, m + 1, b);
+
+    try BigInt.mul(out, l, r);
+}


### PR DESCRIPTION
I added a version of factorial and parallel factorial in Zig and Go. The Zig version runs a lot faster, but that is mostly because [gmp](https://gmplib.org/) tends to be a lot faster than Go's BigInt implementation. I added a linear and parallel version of both tests just to show the gains from running in parallel.

I left out the README because I thought it would be better for you to generate the speed comparisons on your computer. You may need to increase `n` depending on how fast your computer is. These are the times I get with the current scripts:
fact-linear-go:  12.90s
fact-go:            8.21s
fact-linear-zig: 1.38s
fact-zig:           0.61s
Also, linear Zig runs as fast as linear C.

Oh, also, the Zig parallel version does not currently compile without minor modifications to the compiler. In `os.zig`, it seems that sometimes it tries to return as cint as a usize and that throws errors. It is a super simple fix. If I have time, I will open an issue and submit a pull request to fix it.

Finally, I left out printing because it is super slow and really skews the results. Go's BigInt prints so horridly slow for some reason (even when just printing to `/dev/null`).