### PR TITLE
Look for factors only up to sqrt + 1

### DIFF
--- a/sieve/sieve2.zig
+++ b/sieve/sieve2.zig
@@ -11,7 +11,7 @@ fn fillSieve(primes_buffer: []u32, start_index: usize) void {
         var n = primes_buffer[fill_i - 1];
         const next_prime = while (true) {
             n += 2;
-            for (primes_buffer[0..fill_i]) |prev_prime| {
+            for (primes_buffer[0..std.math.sqrt(fill_i) + 1]) |prev_prime| {
                 if (n % prev_prime == 0) break;
             } else break n;
         } else unreachable;


### PR DESCRIPTION
No need to keep searching for factors among lower prime numbers once you reach the square root (plus 1) of the number you are testing for primality. If you get there, you can safely quit the search: your number under testing for primality is a prime number. This, by the way, speeds up the program tremendously.